### PR TITLE
remove scripts as it wont work with sub packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,5 @@
                 "OpenOnMake\\Providers\\OpenOnMakeServiceProvider"
             ]
         }
-    },
-    "scripts": {
-        "post-root-package-install": [
-            "@php artisan vendor:publish --tag=open-on-make"
-        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "scripts": {
         "post-root-package-install": [
-            "php artisan vendor:publish --tag=open-on-make"
+            "@php artisan vendor:publish --tag=open-on-make"
         ]
     }
 }


### PR DESCRIPTION
https://getcomposer.org/doc/articles/scripts.md

> Only scripts defined in the root package's composer.json are executed. If a dependency of the root package specifies its own scripts, Composer does not execute those additional scripts.