### PR TITLE
 Ability to Explicitly Disable the Listener

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,12 @@ OPEN_ON_MAKE_FLAGS='-a' // Flags you need passed to the above Command
 
   `php artisan vendor:publish --tag=open-on-make`
 
+You can explicitly disable this package by setting the `OPEN_ON_MAKE_ENABLED` environment variable:
+
+```
+OPEN_ON_MAKE_ENABLED=false
+```
+
 ## Example Editor values
 
 Sublime - `OPEN_ON_MAKE_EDITOR=subl`

--- a/src/Providers/OpenOnMakeServiceProvider.php
+++ b/src/Providers/OpenOnMakeServiceProvider.php
@@ -18,9 +18,11 @@ class OpenOnMakeServiceProvider extends ServiceProvider
             __DIR__.'/../config/open-on-make.php' => config_path('open-on-make.php')
         ], 'open-on-make');
 
-        Event::listen(
-            'Illuminate\Console\Events\CommandFinished',
-            'OpenOnMake\Listeners\OpenOnMake'
-        );
+        if (config('open-on-make.enabled')) {
+            Event::listen(
+                'Illuminate\Console\Events\CommandFinished',
+                'OpenOnMake\Listeners\OpenOnMake'
+            );
+        }
     }
 }

--- a/src/config/open-on-make.php
+++ b/src/config/open-on-make.php
@@ -2,5 +2,6 @@
 
 return [
     'editor' => env('OPEN_ON_MAKE_EDITOR', 'subl'),
-    'flags' => env('OPEN_ON_MAKE_FLAGS', '')
+    'flags' => env('OPEN_ON_MAKE_FLAGS', ''),
+    'enabled' => env('OPEN_ON_MAKE_ENABLED', true),
 ];


### PR DESCRIPTION
Depending on team workflow, not everyone might want this package enabled. This update provides a new configuration to conditionally disable the event listener via environment:

```
OPEN_ON_MAKE_ENABLED=false
```