### PR TITLE
Fix bug when project's folder has space characters

### DIFF
--- a/src/Listeners/OpenOnMake.php
+++ b/src/Listeners/OpenOnMake.php
@@ -49,7 +49,7 @@ class OpenOnMake
             exec(
                 config('open-on-make.editor') . ' ' .
                 config('open-on-make.flags') . ' ' .
-                escapeshellcmd($path)
+                escapeshellcmd('"'.$path.'"')
             );
         }
     }


### PR DESCRIPTION
My project is located in a folder with space in the name and this package doesn't work well with this. It opens 2 new empty tabs in visual studio code.
To fix this i added double quotes to the file path and it works as expected.