### PR TITLE
Automatically strip "App" namespace from file path

### DIFF
--- a/src/Listeners/OpenOnMake.php
+++ b/src/Listeners/OpenOnMake.php
@@ -161,7 +161,11 @@ class OpenOnMake
 
     public function filename()
     {
-        return str_replace('\\', '/', $this->event->input->getArgument('name') . '.php');
+        return preg_replace(
+            ['/\\\\/', '/^App\//'],
+            ['/', ''],
+            $this->event->input->getArgument('name') . '.php'
+        );
     }
 
     public function getTestPath()


### PR DESCRIPTION
Fixes a bug where for eg `./artisan make:model App\\Models\\Monkey` would open the file `app/App/Models/Monkey.php`.