### PR TITLE
Feature/support custom namespaces

### DIFF
--- a/src/Listeners/OpenOnMake.php
+++ b/src/Listeners/OpenOnMake.php
@@ -9,31 +9,10 @@ use Illuminate\Database\Console as DatabaseConsole;
 class OpenOnMake
 {
     protected $paths = [
-        'channel' => 'app/Broadcasting/',
-        'command' => 'app/Console/Commands/',
         'controller' => 'app/Http/Controllers/',
-        'event' => 'app/Events/',
-        'exception' => 'app/Exceptions/',
         'factory' => 'database/factories/',
-        'job' => 'app/Jobs/',
-        'listener' => 'app/Listeners/',
-        'mail' => 'app/Mail/',
-        'middleware' => 'app/Http/Middleware/',
         'migration' => '',
-        'model' => 'app/',
-        'notification' => 'app/Notifications/',
-        'observer' => 'app/Observers/',
-        'policy' => 'app/Policies/',
-        'provider' => 'app/Providers/',
-        'request' => 'app/Http/Requests/',
         'resource' => 'app/Http/Controllers/',
-        'rule' => 'app/Rules/',
-        'seeder' => 'database/seeds/',
-        'feature' => 'tests/Feature/',
-        'unit' => 'tests/Unit/',
-        'widget' => 'app/Widgets/',
-        'observer' => 'app/Observers/',
-        'view' => 'resources/views/',
     ];
 
     protected $commands = [

--- a/src/Listeners/OpenOnMake.php
+++ b/src/Listeners/OpenOnMake.php
@@ -95,7 +95,10 @@ class OpenOnMake
         $command = explode(' ', $this->event->input);
         
         if ($this->isMakeModelCommand($command)) {
-            $name = $command[1];
+
+            $exploded = explode('\\', $command[1]);
+            $name = trim(array_pop($exploded), "'");
+
             if (count($command) > 2) {
                 // remove the `make:model` and $name so left with options only
                 array_shift($command);


### PR DESCRIPTION
The state of the package right now does not support generating classes in custom places, it only supports the default locations.

This pull request aims to provide support for custom namespace and path generation by refactoring the path resolution to not assume the default location, but rather instantiate the generator command class and have it generate the path based on the input.

Although a bit slower and more complex, I believe that this new version provides more general support and covers more cases.