### PR TITLE
Reuse existing class def for ease of change

### DIFF
--- a/src/Listeners/OpenOnMake.php
+++ b/src/Listeners/OpenOnMake.php
@@ -151,7 +151,7 @@ class OpenOnMake
             return $pathMethod->invokeArgs($instance, [$qualifiedName]);
         } else {
             // Migration and View are special cases that do not extend the GeneratorComand. We can handle them like this:
-            if ($reflection->getName() === \Illuminate\Database\Console\Migrations\MigrateMakeCommand::class) {
+            if ($reflection->getName() === $this->commands['migrate']) {
                 return $this->getLatestMigrationFile();
             } else {
                 // This will look for the filename as a last resort


### PR DESCRIPTION
Realized I can reuse the $commands array to determine the Class so that if the path is ever updated I would not have to update in two places.