### PR TITLE
Require laravel/helpers for string helpers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "require": {
         "php" : "~7.0",
         "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0|~6.0.0",
+        "laravel/helpers": "^1.1",
         "symfony/finder": "~3.3|^4.0",
         "imliam/laravel-env-set-command": "^1.0.0"
     },


### PR DESCRIPTION
Laravel 6 string helpers have been removed and added to the `laravel/helpers` package. Need it to install correctly or will get this error: 

```
Symfony\Component\Debug\Exception\FatalThrowableError  : Call to undefined function OpenOnMake\Listeners\str_contains()

at /code/vendor/ahuggins/open-on-make/src/Listeners/OpenOnMake.php:196
```