### PR TITLE
Fix error when command is empty

### DIFF
--- a/src/Check.php
+++ b/src/Check.php
@@ -13,7 +13,7 @@ class Check
         return config('app.env') !== 'production';
     }
 
-    public static function executedCommandWasMakeCommand(string $command) : bool
+    public static function executedCommandWasMakeCommand(string $command = null) : bool
     {
         return str_contains($command, 'make:');
     }

--- a/tests/unit/CheckTest.php
+++ b/tests/unit/CheckTest.php
@@ -17,7 +17,7 @@ class CheckTest extends TestCase
     /** @test */
     public function it_checks_if_empty_command_is_not_a_make_model_command()
     {
-        $this->assertFalse(Check::isMakeModelCommand());
+        $this->assertFalse(Check::isMakeModelCommand(null));
     }
 
     /** @test */

--- a/tests/unit/CheckTest.php
+++ b/tests/unit/CheckTest.php
@@ -15,6 +15,12 @@ use OpenOnMake\Testing\NotGenerator;
 class CheckTest extends TestCase
 {
     /** @test */
+    public function it_checks_if_empty_command_is_not_a_make_model_command()
+    {
+        $this->assertFalse(Check::isMakeModelCommand());
+    }
+
+    /** @test */
     public function it_verifies_the_command_run_is_a_make_command()
     {
         $this->assertTrue(Check::executedCommandWasMakeCommand('make:model'));

--- a/tests/unit/CheckTest.php
+++ b/tests/unit/CheckTest.php
@@ -17,7 +17,7 @@ class CheckTest extends TestCase
     /** @test */
     public function it_checks_if_empty_command_is_not_a_make_model_command()
     {
-        $this->assertFalse(Check::isMakeModelCommand(null));
+        $this->assertFalse(Check::isMakeModelCommand(''));
     }
 
     /** @test */


### PR DESCRIPTION
Currently, running `php artisan` with no arguments throws an error. This fixes the issue.