### PR TITLE
Remove trailing comma for PHP 7.2 compatibility

### DIFF
--- a/src/Providers/OpenOnMakeServiceProvider.php
+++ b/src/Providers/OpenOnMakeServiceProvider.php
@@ -25,7 +25,7 @@ class OpenOnMakeServiceProvider extends ServiceProvider
         if (config('open-on-make.enabled')) {
             Event::listen(
                 'Illuminate\Console\Events\CommandFinished',
-                'OpenOnMake\Listeners\OpenOnMake',
+                'OpenOnMake\Listeners\OpenOnMake'
             );
         }
 


### PR DESCRIPTION
In the composer.json file PHP 7.2 is listed as required, but trailing commas in functions are not supported in it, so we should skip them to remain backward compatible.